### PR TITLE
[fix] 的を吸いきるのに必要な秒数が、指定したとおりにならない問題を修正

### DIFF
--- a/Assets/Hondo Harun/prehub/GameObject.prefab
+++ b/Assets/Hondo Harun/prehub/GameObject.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 673b3ab0ec381f042a057d38de0ace25, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  vacuumDuration: 10
+  vacuumDuration: 2.5
   destroyPoint: 100
   point: 1
 --- !u!212 &367345658687194190

--- a/Assets/Hondo Harun/terget.cs
+++ b/Assets/Hondo Harun/terget.cs
@@ -6,16 +6,28 @@ public class terget : MonoBehaviour
     [SerializeField] int destroyPoint = 10;
     [SerializeField] int point = 1;
 
+    bool isHitFrame;
+
     void Update()
     {
         //下方向に的が移動し続ける
         transform.Translate(Vector3.down * Time.deltaTime);
+        isHitFrame = false;
     }
 
     public void All()
     {
+        // 1フレーム内で複数回ヒットしないように
+        if (isHitFrame)
+        {
+            Debug.Log($"isHitFrame {name}");
+            return;
+        }
+        isHitFrame = true;
+
         //的が小さくなっていく
-        var vacuum = Time.deltaTime / vacuumDuration; // Todo: vacuumDurationちょうどで吸引しきれるようにしたいけどなってないです
+        // 物理更新サイクルでは Time.deltaTime が fixedTime に置き換えられる
+        var vacuum = Time.deltaTime / vacuumDuration; 
         var getSmall = transform.localScale -= Vector3.one * vacuum;
         //的の大きさ（X値）がゼロ以下になると・・・・
         if (getSmall.x <= 0)

--- a/Assets/Main/M_InGame.unity
+++ b/Assets/Main/M_InGame.unity
@@ -491,7 +491,7 @@ PrefabInstance:
       objectReference: {fileID: 598329284}
     - target: {fileID: 4500196003853715204, guid: ad1bea44ac74cad40ab60cbb9dd4e365, type: 3}
       propertyPath: _spawnInterval
-      value: 0.5
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4500196003853715204, guid: ad1bea44ac74cad40ab60cbb9dd4e365, type: 3}
       propertyPath: _currentGameState

--- a/Assets/RintaroSato/Bullet.cs
+++ b/Assets/RintaroSato/Bullet.cs
@@ -13,19 +13,11 @@ public class Bullet : MonoBehaviour
             //的を伸縮
             target.All();
         }
-        //弾丸を削除
-        Destroy(gameObject);
-    }
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        Destroy(gameObject);
     }
 }

--- a/Assets/RintaroSato/Gun.cs
+++ b/Assets/RintaroSato/Gun.cs
@@ -6,17 +6,11 @@ public class Gun : MonoBehaviour
 {
     public GameObject bulletPrefab;//弾丸のPrefab
     public Transform firepoint;//発射位置
-    public float bulletSpeed = 20f;//弾丸の速度
     //座標用の変数
     Vector3 mousePos, worldPos;
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
 
-    // Update is called once per frame
-    void Update()
+    // Bulletの衝突は物理更新サイクルで行われるためFixedUpdate内で生成しないとおかしくなる
+    void FixedUpdate()
     {
         //マウスの座標の取得
         mousePos = Input.mousePosition;
@@ -29,12 +23,10 @@ public class Gun : MonoBehaviour
             Shoot();
         }
     }
+
     void Shoot()
     {
         //弾丸を生成
-        GameObject bullet = Instantiate(bulletPrefab, firepoint.position, firepoint.rotation);
-        //0.1fごとに消す
-        Destroy(bullet, 0.1f);
+        Instantiate(bulletPrefab, firepoint.position, firepoint.rotation);
     }
-    
 }

--- a/Assets/RintaroSato/play.cs
+++ b/Assets/RintaroSato/play.cs
@@ -13,25 +13,4 @@ public class play : MonoBehaviour
         //カーソルを自前のカーソルに変更
         Cursor.SetCursor(cursor, new Vector2(cursor.width / 2, cursor.height / 2), CursorMode.ForceSoftware);
     }
-
-    // Update is called once per frame
-    void Update()
-    {
-        //マウスの左クリックで撃つ
-        if (Input.GetButton("Fire1"))
-        {
-            Shot();
-        }
-    }
-    //敵を撃つ
-    void Shot()
-    {
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-        RaycastHit hit;
-
-        if(Physics.Raycast(ray,out hit, 100f, LayerMask.GetMask("Enemy")))
-        {
-            Destroy(hit.collider.gameObject);
-        }
-    }
 }


### PR DESCRIPTION
Updateで毎フレーム生成したBulletが、物理サイクル内で全て的に衝突。衝突時の縮小処理でTime.deltaTimeを使っていたが物理サイクル内なのでfixedTimeに置き換えられており、FixedUpdateが呼び出される前にUpdateが呼び出された回数*0.02が毎フレーム縮小されるようになっていた